### PR TITLE
Vulkan - Implement framebuffer and texture

### DIFF
--- a/Kerberos/src/Kerberos/Application.cpp
+++ b/Kerberos/src/Kerberos/Application.cpp
@@ -24,10 +24,10 @@ namespace Kerberos
 		m_Window = Window::Create(props);
 		m_Window->SetEventCallback(BIND_EVENT_FN(Application::OnEvent));
 
-		Renderer::Init();
-
 		m_ImGuiLayer = new ImGuiLayer();
 		PushOverlay(m_ImGuiLayer);
+
+		Renderer::Init();
 	}
 
 	Application::~Application() = default;

--- a/Kerberos/src/Kerberos/Renderer/Buffer.h
+++ b/Kerberos/src/Kerberos/Renderer/Buffer.h
@@ -116,6 +116,12 @@ namespace Kerberos
 		virtual void SetLayout(const BufferLayout& layout) = 0;
 		virtual const BufferLayout& GetLayout() const = 0;
 
+		template<typename T>
+		T& As()
+		{
+			return *reinterpret_cast<T*>(this);
+		}
+
 		static Ref<VertexBuffer> Create(const float* vertices, uint32_t size);
 		static Ref<VertexBuffer> Create(uint32_t size);
 	};
@@ -129,6 +135,12 @@ namespace Kerberos
 		virtual void Unbind() const = 0;
 
 		virtual uint32_t GetCount() const = 0;
+
+        template<typename T>
+		T& As()
+		{
+			return *reinterpret_cast<T*>(this);
+		}
 
 		static Ref<IndexBuffer> Create(const uint32_t* indices, uint32_t count);
 	};

--- a/Kerberos/src/Kerberos/Renderer/Buffer.h
+++ b/Kerberos/src/Kerberos/Renderer/Buffer.h
@@ -119,7 +119,7 @@ namespace Kerberos
 		template<typename T>
 		T& As()
 		{
-			return *reinterpret_cast<T*>(this);
+			return *static_cast<T*>(this);
 		}
 
 		static Ref<VertexBuffer> Create(const float* vertices, uint32_t size);
@@ -139,7 +139,7 @@ namespace Kerberos
         template<typename T>
 		T& As()
 		{
-			return *reinterpret_cast<T*>(this);
+			return *static_cast<T*>(this);
 		}
 
 		static Ref<IndexBuffer> Create(const uint32_t* indices, uint32_t count);

--- a/Kerberos/src/Kerberos/Renderer/Framebuffer.h
+++ b/Kerberos/src/Kerberos/Renderer/Framebuffer.h
@@ -63,6 +63,12 @@ namespace Kerberos
 		virtual FramebufferSpecification& GetSpecification() = 0;
 		virtual const FramebufferSpecification& GetSpecification() const = 0;
 
+		template<typename T>
+		T& As()
+		{
+			return *reinterpret_cast<T*>(this);
+		}
+
 		static Ref<Framebuffer> Create(const FramebufferSpecification& spec);
 	};
 }

--- a/Kerberos/src/Kerberos/Renderer/Framebuffer.h
+++ b/Kerberos/src/Kerberos/Renderer/Framebuffer.h
@@ -66,7 +66,7 @@ namespace Kerberos
 		template<typename T>
 		T& As()
 		{
-			return *reinterpret_cast<T*>(this);
+			return *static_cast<T*>(this);
 		}
 
 		static Ref<Framebuffer> Create(const FramebufferSpecification& spec);

--- a/Kerberos/src/Kerberos/Renderer/Renderer.cpp
+++ b/Kerberos/src/Kerberos/Renderer/Renderer.cpp
@@ -14,7 +14,7 @@ namespace Kerberos
 		RenderCommand::SetupRendererAPI();
 		RenderCommand::Init();
 
-		//Renderer2D::Init();
+		Renderer2D::Init();
 		Renderer3D::Init();
 	}
 

--- a/Kerberos/src/Kerberos/Renderer/Renderer.cpp
+++ b/Kerberos/src/Kerberos/Renderer/Renderer.cpp
@@ -14,7 +14,7 @@ namespace Kerberos
 		RenderCommand::SetupRendererAPI();
 		RenderCommand::Init();
 
-		Renderer2D::Init();
+		//Renderer2D::Init();
 		Renderer3D::Init();
 	}
 

--- a/Kerberos/src/Kerberos/Renderer/Shader.h
+++ b/Kerberos/src/Kerberos/Renderer/Shader.h
@@ -28,6 +28,12 @@ namespace Kerberos
 
 		virtual const std::string& GetName() const = 0;
 
+		template<typename T>
+		T& As()
+		{
+			return *reinterpret_cast<T*>(this);
+		}
+
 		static Ref<Shader> Create(const std::string& filepath);
 		static Ref<Shader> Create(const std::string& name, const std::string& vertexSrc, const std::string& fragmentSrc);
 	};

--- a/Kerberos/src/Kerberos/Renderer/Shader.h
+++ b/Kerberos/src/Kerberos/Renderer/Shader.h
@@ -31,7 +31,7 @@ namespace Kerberos
 		template<typename T>
 		T& As()
 		{
-			return *reinterpret_cast<T*>(this);
+			return *static_cast<T*>(this);
 		}
 
 		static Ref<Shader> Create(const std::string& filepath);

--- a/Kerberos/src/Kerberos/Renderer/SubTexture2D.h
+++ b/Kerberos/src/Kerberos/Renderer/SubTexture2D.h
@@ -17,7 +17,7 @@ namespace Kerberos
 		template<typename T>
 		T& As()
 		{
-			return *reinterpret_cast<T*>(this);
+			return *static_cast<T*>(this);
 		}
 
 		static Ref<SubTexture2D> CreateFromCoords(const Ref<Texture2D>& texture, const glm::vec2& coords, const glm::vec2& cellSize, const glm::vec2& spriteSize);

--- a/Kerberos/src/Kerberos/Renderer/SubTexture2D.h
+++ b/Kerberos/src/Kerberos/Renderer/SubTexture2D.h
@@ -14,6 +14,12 @@ namespace Kerberos
 		Ref<Texture2D> GetTexture() const { return m_Texture; }
 		const glm::vec2* GetTexCoords() const { return m_TexCoords; }
 
+		template<typename T>
+		T& As()
+		{
+			return *reinterpret_cast<T*>(this);
+		}
+
 		static Ref<SubTexture2D> CreateFromCoords(const Ref<Texture2D>& texture, const glm::vec2& coords, const glm::vec2& cellSize, const glm::vec2& spriteSize);
 	private:
 		Ref<Texture2D> m_Texture;

--- a/Kerberos/src/Kerberos/Renderer/Texture.h
+++ b/Kerberos/src/Kerberos/Renderer/Texture.h
@@ -19,6 +19,12 @@ namespace Kerberos
 		virtual void SetData(void* data, uint32_t size) = 0;
 
 		virtual bool operator==(const Texture& other) const = 0;
+
+		template<typename T>
+		T& As()
+		{
+			return *reinterpret_cast<T*>(this);
+		}
 	};
 
 	class Texture2D : public Texture

--- a/Kerberos/src/Kerberos/Renderer/Texture.h
+++ b/Kerberos/src/Kerberos/Renderer/Texture.h
@@ -23,7 +23,7 @@ namespace Kerberos
 		template<typename T>
 		T& As()
 		{
-			return *reinterpret_cast<T*>(this);
+			return *static_cast<T*>(this);
 		}
 	};
 

--- a/Kerberos/src/Kerberos/Renderer/UniformBuffer.h
+++ b/Kerberos/src/Kerberos/Renderer/UniformBuffer.h
@@ -13,7 +13,7 @@ namespace Kerberos
 		template<typename T>
 		T& As()
 		{
-			return *reinterpret_cast<T*>(this);
+			return *static_cast<T*>(this);
 		}
 
 		static Ref<UniformBuffer> Create(uint32_t size, uint32_t binding);

--- a/Kerberos/src/Kerberos/Renderer/UniformBuffer.h
+++ b/Kerberos/src/Kerberos/Renderer/UniformBuffer.h
@@ -10,6 +10,12 @@ namespace Kerberos
 		virtual ~UniformBuffer() = default;
 		virtual void SetData(const void* data, uint32_t size, uint32_t offset = 0) = 0;
 
+		template<typename T>
+		T& As()
+		{
+			return *reinterpret_cast<T*>(this);
+		}
+
 		static Ref<UniformBuffer> Create(uint32_t size, uint32_t binding);
 	};
 }

--- a/Kerberos/src/Kerberos/Renderer/VertexArray.h
+++ b/Kerberos/src/Kerberos/Renderer/VertexArray.h
@@ -19,6 +19,12 @@ namespace Kerberos
 		virtual const std::vector<Ref<VertexBuffer>>& GetVertexBuffers() const = 0;
 		virtual const Ref<IndexBuffer>& GetIndexBuffer() const = 0;
 
+		template<typename T>
+		T& As()
+		{
+			return *reinterpret_cast<T*>(this);
+		}
+
 		static Ref<VertexArray> Create();
 	};
 }

--- a/Kerberos/src/Kerberos/Renderer/VertexArray.h
+++ b/Kerberos/src/Kerberos/Renderer/VertexArray.h
@@ -22,7 +22,7 @@ namespace Kerberos
 		template<typename T>
 		T& As()
 		{
-			return *reinterpret_cast<T*>(this);
+			return *static_cast<T*>(this);
 		}
 
 		static Ref<VertexArray> Create();

--- a/Kerberos/src/Platform/Vulkan/VulkanBuffer.cpp
+++ b/Kerberos/src/Platform/Vulkan/VulkanBuffer.cpp
@@ -93,11 +93,12 @@ namespace Kerberos
 
 	void VulkanVertexBuffer::SetLayout(const BufferLayout& layout)
 	{
+		m_Layout = layout;
 	}
 
 	const BufferLayout& VulkanVertexBuffer::GetLayout() const
 	{
-		return BufferLayout(); /// TODO: Placeholder return value, replace with actual layout
+		return m_Layout;
 	}
 
 	VulkanIndexBuffer::VulkanIndexBuffer(const uint32_t* indices, const uint32_t count)

--- a/Kerberos/src/Platform/Vulkan/VulkanBuffer.h
+++ b/Kerberos/src/Platform/Vulkan/VulkanBuffer.h
@@ -26,6 +26,8 @@ namespace Kerberos
 	private:
 		VkBuffer m_Buffer = VK_NULL_HANDLE;
 		VkDeviceMemory m_BufferMemory = VK_NULL_HANDLE;
+
+		BufferLayout m_Layout;
 	};	
 
 	class VulkanIndexBuffer final : public IndexBuffer

--- a/Kerberos/src/Platform/Vulkan/VulkanContext.cpp
+++ b/Kerberos/src/Platform/Vulkan/VulkanContext.cpp
@@ -984,7 +984,7 @@ namespace Kerberos
 		}
 	}
 
-	VkCommandBuffer VulkanContext::GetCommandBuffer() const 
+	VkCommandBuffer VulkanContext::GetOneTimeCommandBuffer() const 
 	{
 		const VkCommandPool commandPool = m_CommandPool;
 

--- a/Kerberos/src/Platform/Vulkan/VulkanContext.cpp
+++ b/Kerberos/src/Platform/Vulkan/VulkanContext.cpp
@@ -984,6 +984,77 @@ namespace Kerberos
 		}
 	}
 
+	VkCommandBuffer VulkanContext::GetCommandBuffer() const 
+	{
+		const VkCommandPool commandPool = m_CommandPool;
+
+		VkCommandBufferAllocateInfo allocInfo{};
+		allocInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+		allocInfo.commandPool = commandPool;
+		allocInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+		allocInfo.commandBufferCount = 1;
+
+		VkCommandBuffer commandBuffer;
+		if (const VkResult result = vkAllocateCommandBuffers(m_Device, &allocInfo, &commandBuffer); result != VK_SUCCESS)
+		{
+			KBR_CORE_ASSERT(false, "Failed to allocate command buffer! Result: {0}", VulkanHelpers::VkResultToString(result));
+			throw std::runtime_error("failed to allocate command buffer!");
+		}
+
+		VkCommandBufferBeginInfo beginInfo{};
+		beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+		beginInfo.flags |= VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+
+		if (const VkResult result = vkBeginCommandBuffer(commandBuffer, &beginInfo); result != VK_SUCCESS)
+		{
+			KBR_CORE_ASSERT(false, "Failed to begin command buffer! Result: {0}", VulkanHelpers::VkResultToString(result));
+			throw std::runtime_error("failed to begin command buffer!");
+		}
+
+		return commandBuffer;
+	}
+
+	void VulkanContext::SubmitCommandBuffer(const VkCommandBuffer commandBuffer) const 
+	{
+		constexpr uint64_t fenceWaitTimeout = 10000000000000;
+
+		VkSubmitInfo submitInfo{};
+		submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+		submitInfo.commandBufferCount = 1;
+		submitInfo.pCommandBuffers = &commandBuffer;
+
+		if (const VkResult result = vkEndCommandBuffer(commandBuffer); result != VK_SUCCESS)
+		{
+			KBR_CORE_ASSERT(false, "Failed to end command buffer! Result: {0}", VulkanHelpers::VkResultToString(result));
+			throw std::runtime_error("failed to end command buffer!");
+		}
+
+		VkFenceCreateInfo fenceInfo{};
+		fenceInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+		fenceInfo.flags = 0;
+
+		VkFence fence;
+		if (const VkResult result = vkCreateFence(m_Device, &fenceInfo, nullptr, &fence); result != VK_SUCCESS)
+		{
+			KBR_CORE_ASSERT(false, "Failed to create fence! Result: {0}", VulkanHelpers::VkResultToString(result));
+			throw std::runtime_error("failed to create fence!");
+		}
+
+		if (const VkResult result = vkQueueSubmit(m_GraphicsQueue, 1, &submitInfo, fence); result != VK_SUCCESS)
+		{
+			KBR_CORE_ASSERT(false, "Failed to submit command buffer! Result: {0}", VulkanHelpers::VkResultToString(result));
+			throw std::runtime_error("failed to submit command buffer!");
+		}
+
+		if (const VkResult result = vkWaitForFences(m_Device, 1, &fence, VK_TRUE, fenceWaitTimeout); result != VK_SUCCESS)
+		{
+			KBR_CORE_ASSERT(false, "Failed to wait for fence! Result: {0}", VulkanHelpers::VkResultToString(result));
+			throw std::runtime_error("failed to wait for fence!");
+		}
+
+		vkDestroyFence(m_Device, fence, nullptr);
+	}
+
 
 	bool VulkanContext::CheckValidationLayerSupport()
 	{

--- a/Kerberos/src/Platform/Vulkan/VulkanContext.cpp
+++ b/Kerberos/src/Platform/Vulkan/VulkanContext.cpp
@@ -296,11 +296,15 @@ namespace Kerberos
 		scissor.extent = m_SwapChainExtent;
 		vkCmdSetScissor(commandBuffer, 0, 1, &scissor);
 
-		const VkBuffer vertexBuffers[] = { m_VertexBuffer->GetVkBuffer() };
+		const auto& vertexBuffer = m_VertexBuffer->As<VulkanVertexBuffer>();
+
+		const VkBuffer vertexBuffers[] = { vertexBuffer.GetVkBuffer() };
 		constexpr VkDeviceSize offsets[] = { 0 };
 		vkCmdBindVertexBuffers(commandBuffer, 0, 1, vertexBuffers, offsets);
 
-		vkCmdBindIndexBuffer(commandBuffer, m_IndexBuffer->GetVkBuffer(), 0, static_cast<VkIndexType>(m_IndexBuffer->GetType()));
+		const auto& indexBuffer = m_IndexBuffer->As<VulkanIndexBuffer>();
+
+		vkCmdBindIndexBuffer(commandBuffer, indexBuffer.GetVkBuffer(), 0, static_cast<VkIndexType>(indexBuffer.GetType()));
 
 		//vkCmdDraw(commandBuffer, 32, 1, 0, 0);
 

--- a/Kerberos/src/Platform/Vulkan/VulkanContext.h
+++ b/Kerberos/src/Platform/Vulkan/VulkanContext.h
@@ -139,8 +139,8 @@ namespace Kerberos
 
 		uint32_t m_CurrentFrame = 0;
 
-		Scope<VulkanVertexBuffer> m_VertexBuffer;
-		Scope<VulkanIndexBuffer> m_IndexBuffer;
+		Scope<VertexBuffer> m_VertexBuffer;
+		Scope<IndexBuffer> m_IndexBuffer;
 
 		static VulkanContext* s_Instance;
 	};

--- a/Kerberos/src/Platform/Vulkan/VulkanContext.h
+++ b/Kerberos/src/Platform/Vulkan/VulkanContext.h
@@ -55,7 +55,7 @@ namespace Kerberos
 		* @brief Returns a one-time use command buffer that can be used to record commands.
 		* The command buffer must be submitted using SubmitCommandBuffer() after recording.
 		*/
-		VkCommandBuffer GetCommandBuffer() const;
+		VkCommandBuffer GetOneTimeCommandBuffer() const;
 
 		/**
 		* Submit a command buffer for execution.

--- a/Kerberos/src/Platform/Vulkan/VulkanContext.h
+++ b/Kerberos/src/Platform/Vulkan/VulkanContext.h
@@ -50,6 +50,17 @@ namespace Kerberos
 
 		VkDescriptorPool GetImGuiDescriptorPool() const { return m_ImGuiDescriptorPool; }
 
+		/**
+		* @brief Returns a one-time use command buffer that can be used to record commands.
+		* The command buffer must be submitted using SubmitCommandBuffer() after recording.
+		*/
+		VkCommandBuffer GetCommandBuffer() const;
+
+		/**
+		* Submit a command buffer for execution.
+		*/
+		void SubmitCommandBuffer(VkCommandBuffer commandBuffer) const;
+
 		static VulkanContext& Get() { return *s_Instance; }
 
 	private:

--- a/Kerberos/src/Platform/Vulkan/VulkanContext.h
+++ b/Kerberos/src/Platform/Vulkan/VulkanContext.h
@@ -47,6 +47,7 @@ namespace Kerberos
 		VkPipeline GetPipeline() const { return m_GraphicsPipeline; }
 		std::vector<VkFramebuffer> GetSwapChainFramebuffers() const { return m_SwapChainFramebuffers; }
 		uint32_t GetCurrentFrameIndex() const { return m_CurrentFrame; }
+		VkCommandPool GetCommandPool() const { return m_CommandPool; }
 
 		VkDescriptorPool GetImGuiDescriptorPool() const { return m_ImGuiDescriptorPool; }
 

--- a/Kerberos/src/Platform/Vulkan/VulkanFramebuffer.cpp
+++ b/Kerberos/src/Platform/Vulkan/VulkanFramebuffer.cpp
@@ -1,8 +1,30 @@
 #include "kbrpch.h"
 #include "VulkanFramebuffer.h"
 
+#include "VulkanHelpers.h"
+
 namespace Kerberos
 {
+	namespace Utils
+	{
+		static VkFormat FramebufferTextureFormatToVulkanFormat(const FramebufferTextureFormat format)
+		{
+			switch (format)
+			{
+			case FramebufferTextureFormat::RGBA8:           return VK_FORMAT_R8G8B8A8_UNORM;
+			case FramebufferTextureFormat::DEPTH24STENCIL8: return VK_FORMAT_D24_UNORM_S8_UINT;
+			case FramebufferTextureFormat::None:            return VK_FORMAT_UNDEFINED;
+			}
+			KBR_CORE_ASSERT(false, "Unknown FramebufferTextureFormat!");
+			return VK_FORMAT_UNDEFINED;
+		}
+
+		static bool IsDepthFormat(const FramebufferTextureFormat format)
+		{
+			return format == FramebufferTextureFormat::DEPTH24STENCIL8;
+		}
+	}
+
 	VulkanFramebuffer::VulkanFramebuffer(const FramebufferSpecification& spec)
 		: m_Specification(spec)
 	{

--- a/Kerberos/src/Platform/Vulkan/VulkanFramebuffer.cpp
+++ b/Kerberos/src/Platform/Vulkan/VulkanFramebuffer.cpp
@@ -310,7 +310,7 @@ namespace Kerberos
 		}
 
 		std::vector<VkClearValue> clearValues;
-		clearValues.push_back({{0.0f, 0.0f, 0.0f, 1.0f}});
+		clearValues.push_back({{{0.0f, 0.0f, 0.0f, 1.0f}}});
 		if (m_DepthAttachmentSpec.TextureFormat != FramebufferTextureFormat::None)
 		{
 			clearValues.push_back({{{1.0f, 0}}});
@@ -320,7 +320,7 @@ namespace Kerberos
 		renderPassInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
 		renderPassInfo.renderPass = m_RenderPass;
 		renderPassInfo.framebuffer = m_Framebuffer;
-		renderPassInfo.renderArea.offset = { 0, 0 };
+		renderPassInfo.renderArea.offset = { .x = 0, .y = 0 };
 		renderPassInfo.renderArea.extent.width = m_Specification.Width;
 		renderPassInfo.renderArea.extent.height = m_Specification.Height;
 		renderPassInfo.clearValueCount = static_cast<uint32_t>(clearValues.size());

--- a/Kerberos/src/Platform/Vulkan/VulkanFramebuffer.cpp
+++ b/Kerberos/src/Platform/Vulkan/VulkanFramebuffer.cpp
@@ -1,6 +1,9 @@
 #include "kbrpch.h"
 #include "VulkanFramebuffer.h"
 
+#include <backends/imgui_impl_vulkan.h>
+
+#include "VulkanContext.h"
 #include "VulkanHelpers.h"
 
 namespace Kerberos
@@ -25,39 +28,473 @@ namespace Kerberos
 		}
 	}
 
-	VulkanFramebuffer::VulkanFramebuffer(const FramebufferSpecification& spec)
-		: m_Specification(spec)
+	VulkanFramebuffer::VulkanFramebuffer(FramebufferSpecification spec)
+		: m_Specification(std::move(spec))
 	{
+		KBR_PROFILE_FUNCTION();
 
+		for (auto format : m_Specification.Attachments.Attachments)
+		{
+			if (Utils::IsDepthFormat(format.TextureFormat))
+			{
+				m_DepthAttachmentSpec = format;
+			}
+			else
+			{
+				m_ColorAttachmentSpecs.emplace_back(format);
+			}
+		}
+
+		KBR_CORE_ASSERT(!m_ColorAttachmentSpecs.empty(), "Framebuffer must have at least one color attachment!");
+		KBR_CORE_ASSERT(m_DepthAttachmentSpec.TextureFormat != FramebufferTextureFormat::None, "Framebuffer must have a depth attachment!");
+		KBR_CORE_ASSERT(m_Specification.Width > 0 && m_Specification.Height > 0, "Framebuffer dimensions must be greater than zero!");
+		KBR_CORE_ASSERT(m_Specification.Samples > 0, "Framebuffer samples must be greater than zero!");
+
+		KBR_CORE_ASSERT(m_Specification.Samples == 1, "Vulkan currently doesn't support multisampling!");
+		KBR_CORE_ASSERT(m_ColorAttachmentSpecs.size() == 1, "VulkanFramebuffer currently only supports one color attachment!");
+
+		Invalidate();
+	}
+
+	VulkanFramebuffer::~VulkanFramebuffer() 
+	{
+		KBR_PROFILE_FUNCTION();
+
+		ReleaseResources();
 	}
 
 	void VulkanFramebuffer::Invalidate()
 	{
+		KBR_PROFILE_FUNCTION();
 
+		const VulkanContext& context = VulkanContext::Get();
+
+		vkDeviceWaitIdle(context.GetDevice());
+
+		if (m_Framebuffer != VK_NULL_HANDLE)
+		{
+			ReleaseResources();
+		}
+
+		{
+			size_t colorAttachmentCount = m_ColorAttachmentSpecs.size();
+			m_ColorAttachmentMemories.resize(colorAttachmentCount);
+			m_ColorAttachments.resize(colorAttachmentCount);
+			m_ColorAttachmentViews.resize(colorAttachmentCount);
+		}
+
+
+		const VkFormat colorFormat = Utils::FramebufferTextureFormatToVulkanFormat(m_ColorAttachmentSpecs[0].TextureFormat);
+
+		CreateImage(
+			m_Specification.Width, 
+			m_Specification.Height, 
+			colorFormat, 
+			VK_IMAGE_TILING_OPTIMAL,
+			VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+			m_ColorAttachments[0], m_ColorAttachmentMemories[0]);
+
+		CreateImageView(m_ColorAttachments[0], colorFormat, VK_IMAGE_ASPECT_COLOR_BIT, m_ColorAttachmentViews[0]);
+
+		std::vector<VkAttachmentDescription> attachmentDescriptions;
+		attachmentDescriptions.resize(m_ColorAttachmentSpecs.size());
+		for (size_t i = 0; i < m_ColorAttachmentSpecs.size(); ++i)
+		{
+			attachmentDescriptions[i].format = Utils::FramebufferTextureFormatToVulkanFormat(m_ColorAttachmentSpecs[i].TextureFormat);
+			attachmentDescriptions[i].samples = VK_SAMPLE_COUNT_1_BIT; /// Make this customizable when supporting multisampling
+			attachmentDescriptions[i].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+			attachmentDescriptions[i].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+			attachmentDescriptions[i].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+			attachmentDescriptions[i].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+			attachmentDescriptions[i].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+			attachmentDescriptions[i].finalLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+		}
+
+
+		if (m_DepthAttachmentSpec.TextureFormat != FramebufferTextureFormat::None)
+		{
+			const VkFormat depthFormat = Utils::FramebufferTextureFormatToVulkanFormat(m_DepthAttachmentSpec.TextureFormat);
+
+			CreateImage(
+				m_Specification.Width, 
+				m_Specification.Height, 
+				depthFormat, 
+				VK_IMAGE_TILING_OPTIMAL,
+				VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+				m_DepthAttachment, m_DepthAttachmentMemory);
+
+			CreateImageView(m_DepthAttachment, depthFormat, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, m_DepthAttachmentView);
+
+			VkAttachmentDescription depthAttachmentDescription{};
+			depthAttachmentDescription.format = depthFormat;
+			depthAttachmentDescription.samples = VK_SAMPLE_COUNT_1_BIT; /// Make this customizable when supporting multisampling
+			depthAttachmentDescription.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+			depthAttachmentDescription.storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+			depthAttachmentDescription.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+			depthAttachmentDescription.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+			depthAttachmentDescription.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+			depthAttachmentDescription.finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+
+			attachmentDescriptions.push_back(depthAttachmentDescription);
+		}
+
+		/// Subpass attachments
+		VkAttachmentReference colorAttachmentRef{};
+		colorAttachmentRef.attachment = 0;
+		colorAttachmentRef.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+		VkAttachmentReference depthAttachmentRef{};
+		if (m_DepthAttachmentSpec.TextureFormat != FramebufferTextureFormat::None)
+		{
+			depthAttachmentRef.attachment = static_cast<uint32_t>(attachmentDescriptions.size() - 1);
+			depthAttachmentRef.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+		}
+
+		/// Subpass creation
+		VkSubpassDescription subpass{};
+		subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+		subpass.colorAttachmentCount = 1;
+		subpass.pColorAttachments = &colorAttachmentRef;
+		if (m_DepthAttachmentSpec.TextureFormat != FramebufferTextureFormat::None)
+		{
+			subpass.pDepthStencilAttachment = &depthAttachmentRef;
+		}
+		else
+		{
+			subpass.pDepthStencilAttachment = nullptr;
+		}
+
+		std::vector<VkSubpassDependency> dependencies(2);
+
+		/// Dependency for transitioning color attachment into the rendes pass
+		dependencies[0].srcSubpass = VK_SUBPASS_EXTERNAL;
+		dependencies[0].dstSubpass = 0;
+		/// Wait for previous operations to finish before starting this subpass
+		dependencies[0].srcStageMask = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
+		/// Transition before starting the subpass
+		dependencies[0].dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+		dependencies[0].srcAccessMask = 0;
+		dependencies[0].dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+		dependencies[0].dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
+
+		/// Dependency for transitioning color attachment after the render pass
+		dependencies[1].srcSubpass = 0;
+		dependencies[1].dstSubpass = VK_SUBPASS_EXTERNAL;
+		dependencies[1].srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+		dependencies[1].dstStageMask = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT; /// Available for sampling in fragment shader
+		dependencies[1].srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+		dependencies[1].dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+		dependencies[1].dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
+
+		/// Create render pass
+		VkRenderPassCreateInfo renderPassInfo{};
+		renderPassInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
+		renderPassInfo.attachmentCount = static_cast<uint32_t>(attachmentDescriptions.size());
+		renderPassInfo.pAttachments = attachmentDescriptions.data();
+		renderPassInfo.subpassCount = 1;
+		renderPassInfo.pSubpasses = &subpass;
+		renderPassInfo.dependencyCount = static_cast<uint32_t>(dependencies.size());
+		renderPassInfo.pDependencies = dependencies.data();
+
+		if (vkCreateRenderPass(context.GetDevice(), &renderPassInfo, nullptr, &m_RenderPass) != VK_SUCCESS)
+		{
+			KBR_CORE_ASSERT(false, "Failed to create render pass!");
+			return;
+		}
+
+		/// Create framebuffer
+		std::vector<VkImageView> framebufferAttachments = m_ColorAttachmentViews;
+		if (m_DepthAttachmentSpec.TextureFormat != FramebufferTextureFormat::None)
+		{
+			framebufferAttachments.push_back(m_DepthAttachmentView);
+		}
+
+		VkFramebufferCreateInfo framebufferInfo{};
+		framebufferInfo.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+		framebufferInfo.renderPass = m_RenderPass;
+		framebufferInfo.attachmentCount = static_cast<uint32_t>(framebufferAttachments.size());
+		framebufferInfo.pAttachments = framebufferAttachments.data();
+		framebufferInfo.width = m_Specification.Width;
+		framebufferInfo.height = m_Specification.Height;
+		framebufferInfo.layers = 1;
+
+		if (vkCreateFramebuffer(context.GetDevice(), &framebufferInfo, nullptr, &m_Framebuffer) != VK_SUCCESS)
+		{
+			KBR_CORE_ASSERT(false, "Failed to create framebuffer!");
+			return;
+		}
+
+		/// Create sampler for color attachment
+		VkSamplerCreateInfo samplerInfo{};
+		samplerInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+		samplerInfo.magFilter = VK_FILTER_LINEAR;
+		samplerInfo.minFilter = VK_FILTER_LINEAR;
+		samplerInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR; /// Make this customizable when supporting mipmapping
+		samplerInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+		samplerInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+		samplerInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+		samplerInfo.anisotropyEnable = VK_FALSE; /// Set to VK_TRUE if anisotropic filtering is supported
+		samplerInfo.minLod = 0.0f;
+		samplerInfo.maxLod = 0.0f;
+		samplerInfo.borderColor = VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK;
+		samplerInfo.unnormalizedCoordinates = VK_FALSE;
+
+		if (vkCreateSampler(context.GetDevice(), &samplerInfo, nullptr, &m_ColorAttachmentSampler) != VK_SUCCESS)
+		{
+			KBR_CORE_ASSERT(false, "Failed to create color attachment sampler!");
+			return;
+		}
+
+		/// Create command pool and command buffer for framebuffer operations
+		VkCommandPoolCreateInfo poolInfo{};
+		poolInfo.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+		poolInfo.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+		poolInfo.queueFamilyIndex = context.GetGraphicsQueueFamilyIndex();
+
+		if (vkCreateCommandPool(context.GetDevice(), &poolInfo, nullptr, &m_CommandPool) != VK_SUCCESS)
+		{
+			KBR_CORE_ASSERT(false, "Failed to create command pool!");
+			return;
+		}
+
+		VkCommandBufferAllocateInfo allocInfo{};
+		allocInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+		allocInfo.commandPool = m_CommandPool;
+		allocInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+		allocInfo.commandBufferCount = 1;
+
+		if (vkAllocateCommandBuffers(context.GetDevice(), &allocInfo, &m_CommandBuffer) != VK_SUCCESS)
+		{
+			KBR_CORE_ASSERT(false, "Failed to allocate command buffer!");
+			return;
+		}
+
+		/// Create fence
+		VkFenceCreateInfo fenceInfo{};
+		fenceInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+		fenceInfo.flags = VK_FENCE_CREATE_SIGNALED_BIT;
+		if (vkCreateFence(context.GetDevice(), &fenceInfo, nullptr, &m_Fence) != VK_SUCCESS)
+		{
+			KBR_CORE_ASSERT(false, "Failed to create fence!");
+			return;
+		}
+
+		/// Create descriptor set for color attachment
+		m_ColorAttachmentDescriptorSet = ImGui_ImplVulkan_AddTexture(m_ColorAttachmentSampler, m_ColorAttachmentViews[0], VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 	}
 
 	void VulkanFramebuffer::Bind()
 	{
+		if (const VkResult result = vkWaitForFences(VulkanContext::Get().GetDevice(), 1, &m_Fence, VK_TRUE, UINT64_MAX); result != VK_SUCCESS)
+		{
+			KBR_CORE_ASSERT(false, "Failed to wait for fence!");
+			return;
+		}
 
+		if (const VkResult result = vkResetFences(VulkanContext::Get().GetDevice(), 1, &m_Fence); result != VK_SUCCESS)
+		{
+			KBR_CORE_ASSERT(false, "Failed to reset fence!");
+			return;
+		}
+
+		vkResetCommandBuffer(m_CommandBuffer, 0);
+
+		VkCommandBufferBeginInfo beginInfo{};
+		beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+		beginInfo.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+		
+		if (vkBeginCommandBuffer(m_CommandBuffer, &beginInfo) != VK_SUCCESS)
+		{
+			KBR_CORE_ASSERT(false, "Failed to begin command buffer!");
+			return;
+		}
+
+		std::vector<VkClearValue> clearValues;
+		clearValues.push_back({{0.0f, 0.0f, 0.0f, 1.0f}});
+		if (m_DepthAttachmentSpec.TextureFormat != FramebufferTextureFormat::None)
+		{
+			clearValues.push_back({{{1.0f, 0}}});
+		}
+
+		VkRenderPassBeginInfo renderPassInfo{};
+		renderPassInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
+		renderPassInfo.renderPass = m_RenderPass;
+		renderPassInfo.framebuffer = m_Framebuffer;
+		renderPassInfo.renderArea.offset = { 0, 0 };
+		renderPassInfo.renderArea.extent.width = m_Specification.Width;
+		renderPassInfo.renderArea.extent.height = m_Specification.Height;
+		renderPassInfo.clearValueCount = static_cast<uint32_t>(clearValues.size());
+		renderPassInfo.pClearValues = clearValues.data();
+
+		vkCmdBeginRenderPass(m_CommandBuffer, &renderPassInfo, VK_SUBPASS_CONTENTS_INLINE);
+
+		VkViewport viewport{};
+		viewport.x = 0.0f;
+		viewport.y = static_cast<float>(m_Specification.Height);
+		viewport.width = static_cast<float>(m_Specification.Width);
+		viewport.height = -static_cast<float>(m_Specification.Height); // Invert Y-axis for Vulkan
+		viewport.minDepth = 0.0f;
+		viewport.maxDepth = 1.0f;
+		vkCmdSetViewport(m_CommandBuffer, 0, 1, &viewport);
+
+		VkRect2D scissor{};
+		scissor.offset = { .x = 0, .y = 0 };
+		scissor.extent.width = m_Specification.Width;
+		scissor.extent.height = m_Specification.Height;
+		vkCmdSetScissor(m_CommandBuffer, 0, 1, &scissor);
 	}
 
 	void VulkanFramebuffer::Unbind()
 	{
+		vkCmdEndRenderPass(m_CommandBuffer);
 
+		if (const VkResult result = vkEndCommandBuffer(m_CommandBuffer); result != VK_SUCCESS)
+		{
+			KBR_CORE_ASSERT(false, "Failed to end command buffer!");
+			return;
+		}
+
+		VkSubmitInfo submitInfo{};
+		submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+		submitInfo.commandBufferCount = 1;
+		submitInfo.pCommandBuffers = &m_CommandBuffer;
+		if (vkQueueSubmit(VulkanContext::Get().GetGraphicsQueue(), 1, &submitInfo, m_Fence) != VK_SUCCESS)
+		{
+			KBR_CORE_ASSERT(false, "Failed to submit command buffer!");
+			return;
+		}
 	}
 
 	void VulkanFramebuffer::Resize(uint32_t width, uint32_t height)
 	{
+		KBR_PROFILE_FUNCTION();
 
+		if (width == 0 || height == 0)
+		{
+			KBR_CORE_WARN("Attempted to resize framebuffer to {0}, {1}", width, height);
+			return;
+		}
+
+		m_Specification.Width = width;
+		m_Specification.Height = height;
+
+		Invalidate();
 	}
 
 	uint64_t VulkanFramebuffer::GetColorAttachmentRendererID(uint32_t index) const
 	{
-		return 0; // Placeholder, should return the renderer ID of the color attachment at the specified index
+		return reinterpret_cast<ImTextureID>(m_ColorAttachmentDescriptorSet);
 	}
 
-	void VulkanFramebuffer::ReleaseResources() const
+	void VulkanFramebuffer::ReleaseResources()
 	{
-		
+		const VulkanContext& context = VulkanContext::Get();
+		const VkDevice device = context.GetDevice();
+
+		vkDeviceWaitIdle(device);
+
+		vkDestroySampler(device, m_ColorAttachmentSampler, nullptr);
+		m_ColorAttachmentSampler = VK_NULL_HANDLE;
+
+		vkDestroyFence(device, m_Fence, nullptr);
+		m_Fence = VK_NULL_HANDLE;
+
+		vkFreeCommandBuffers(device, m_CommandPool, 1, &m_CommandBuffer);
+		vkDestroyCommandPool(device, m_CommandPool, nullptr);
+		m_CommandPool = VK_NULL_HANDLE;
+		m_CommandBuffer = VK_NULL_HANDLE;
+
+		vkDestroyFramebuffer(device, m_Framebuffer, nullptr);
+		vkDestroyRenderPass(device, m_RenderPass, nullptr);
+		m_Framebuffer = VK_NULL_HANDLE;
+		m_RenderPass = VK_NULL_HANDLE;
+
+		vkDestroyImageView(device, m_DepthAttachmentView, nullptr);
+		vkDestroyImage(device, m_DepthAttachment, nullptr);
+		vkFreeMemory(device, m_DepthAttachmentMemory, nullptr);
+		m_DepthAttachment = VK_NULL_HANDLE;
+		m_DepthAttachmentMemory = VK_NULL_HANDLE;
+		m_DepthAttachmentView = VK_NULL_HANDLE;
+
+		for (size_t i = 0; i < m_ColorAttachments.size(); ++i)
+		{
+			vkDestroyImageView(device, m_ColorAttachmentViews[i], nullptr);
+			vkDestroyImage(device, m_ColorAttachments[i], nullptr);
+			vkFreeMemory(device, m_ColorAttachmentMemories[i], nullptr);
+			m_ColorAttachments[i] = VK_NULL_HANDLE;
+			m_ColorAttachmentMemories[i] = VK_NULL_HANDLE;
+			m_ColorAttachmentViews[i] = VK_NULL_HANDLE;
+		}
+		m_ColorAttachments.clear();
+		m_ColorAttachmentMemories.clear();
+		m_ColorAttachmentViews.clear();
+
+		ImGui_ImplVulkan_RemoveTexture(m_ColorAttachmentDescriptorSet);
+	}
+
+	void VulkanFramebuffer::CreateImage(const uint32_t width, const uint32_t height, const VkFormat format, const VkImageTiling tiling,
+		const VkImageUsageFlags usage, const VkMemoryPropertyFlags properties, VkImage& image, VkDeviceMemory& memory) const 
+	{
+		const VulkanContext& context = VulkanContext::Get();
+
+		VkImageCreateInfo imageInfo{};
+		imageInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+		imageInfo.imageType = VK_IMAGE_TYPE_2D;
+		imageInfo.extent.width = width;
+		imageInfo.extent.height = height;
+		imageInfo.extent.depth = 1;
+		imageInfo.mipLevels = 1;
+		imageInfo.arrayLayers = 1;
+		imageInfo.format = format;
+		imageInfo.tiling = tiling;
+		imageInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+		imageInfo.usage = usage;
+		imageInfo.samples = VK_SAMPLE_COUNT_1_BIT; /// Make this also customizable when supporting multisampling
+		imageInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+		if (vkCreateImage(context.GetDevice(), &imageInfo, nullptr, &image) != VK_SUCCESS)
+		{
+			KBR_CORE_ASSERT(false, "Failed to create image!");
+			return;
+		}
+
+		VkMemoryRequirements memRequirements;
+		vkGetImageMemoryRequirements(context.GetDevice(), image, &memRequirements);
+
+		VkMemoryAllocateInfo allocInfo{};
+		allocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+		allocInfo.allocationSize = memRequirements.size;
+		allocInfo.memoryTypeIndex = VulkanHelpers::FindMemoryType(context.GetPhysicalDevice(), memRequirements.memoryTypeBits, properties);
+
+		if (vkAllocateMemory(context.GetDevice(), &allocInfo, nullptr, &memory) != VK_SUCCESS)
+		{
+			KBR_CORE_ASSERT(false, "Failed to allocate image memory!");
+			return;
+		}
+
+		if (vkBindImageMemory(context.GetDevice(), image, memory, 0) != VK_SUCCESS)
+		{
+			KBR_CORE_ASSERT(false, "Failed to bind image memory!");
+		}
+	}
+
+	void VulkanFramebuffer::CreateImageView(const VkImage image, const VkFormat format, const VkImageAspectFlags flags,
+		VkImageView& imageView) const 
+	{
+		VkImageViewCreateInfo viewInfo{};
+		viewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+		viewInfo.image = image;
+		viewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
+		viewInfo.format = format;
+		viewInfo.subresourceRange.aspectMask = flags;
+		viewInfo.subresourceRange.baseMipLevel = 0;
+		viewInfo.subresourceRange.levelCount = 1;
+		viewInfo.subresourceRange.baseArrayLayer = 0;
+		viewInfo.subresourceRange.layerCount = 1;
+
+		if (vkCreateImageView(VulkanContext::Get().GetDevice(), &viewInfo, nullptr, &imageView) != VK_SUCCESS)
+		{
+			KBR_CORE_ASSERT(false, "Failed to create image view!");
+		}
 	}
 }

--- a/Kerberos/src/Platform/Vulkan/VulkanFramebuffer.cpp
+++ b/Kerberos/src/Platform/Vulkan/VulkanFramebuffer.cpp
@@ -433,7 +433,7 @@ namespace Kerberos
 	}
 
 	void VulkanFramebuffer::CreateImage(const uint32_t width, const uint32_t height, const VkFormat format, const VkImageTiling tiling,
-		const VkImageUsageFlags usage, const VkMemoryPropertyFlags properties, VkImage& image, VkDeviceMemory& memory) const 
+		const VkImageUsageFlags usage, const VkMemoryPropertyFlags properties, VkImage& image, VkDeviceMemory& memory) 
 	{
 		const VulkanContext& context = VulkanContext::Get();
 
@@ -479,7 +479,7 @@ namespace Kerberos
 	}
 
 	void VulkanFramebuffer::CreateImageView(const VkImage image, const VkFormat format, const VkImageAspectFlags flags,
-		VkImageView& imageView) const 
+		VkImageView& imageView) 
 	{
 		VkImageViewCreateInfo viewInfo{};
 		viewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;

--- a/Kerberos/src/Platform/Vulkan/VulkanFramebuffer.h
+++ b/Kerberos/src/Platform/Vulkan/VulkanFramebuffer.h
@@ -9,8 +9,8 @@ namespace Kerberos
 	class VulkanFramebuffer final : public Framebuffer
 	{
 	public:
-		explicit VulkanFramebuffer(const FramebufferSpecification& spec);
-		~VulkanFramebuffer() override = default;
+		explicit VulkanFramebuffer(FramebufferSpecification spec);
+		~VulkanFramebuffer() override;
 
 		void Invalidate();
 
@@ -25,12 +25,35 @@ namespace Kerberos
 		const FramebufferSpecification& GetSpecification() const override { return m_Specification; }
 
 	private:
-		void ReleaseResources() const;
+		void ReleaseResources();
+
+		void CreateImage(uint32_t width, uint32_t height, VkFormat format, VkImageTiling tiling, VkImageUsageFlags usage, VkMemoryPropertyFlags properties, VkImage& image, VkDeviceMemory& memory) const;
+		void CreateImageView(VkImage image, VkFormat format, VkImageAspectFlags flags, VkImageView& imageView) const;
 
 	private:
 		FramebufferSpecification m_Specification;
 
 		std::vector<FramebufferTextureSpecification> m_ColorAttachmentSpecs;
 		FramebufferTextureSpecification m_DepthAttachmentSpec = FramebufferTextureFormat::None;
+
+		VkFramebuffer m_Framebuffer = VK_NULL_HANDLE;
+		VkRenderPass m_RenderPass = VK_NULL_HANDLE;
+
+		std::vector<VkImage> m_ColorAttachments;
+		std::vector<VkImageView> m_ColorAttachmentViews;
+		std::vector<VkDeviceMemory> m_ColorAttachmentMemories;
+
+		VkImage m_DepthAttachment = VK_NULL_HANDLE;
+		VkImageView m_DepthAttachmentView = VK_NULL_HANDLE;
+		VkDeviceMemory m_DepthAttachmentMemory = VK_NULL_HANDLE;
+
+		VkSampler m_ColorAttachmentSampler = VK_NULL_HANDLE;
+
+		VkCommandPool m_CommandPool = VK_NULL_HANDLE;
+		VkCommandBuffer m_CommandBuffer = VK_NULL_HANDLE;
+
+		VkFence m_Fence = VK_NULL_HANDLE;
+
+		VkDescriptorSet m_ColorAttachmentDescriptorSet = VK_NULL_HANDLE;
 	};
 }

--- a/Kerberos/src/Platform/Vulkan/VulkanFramebuffer.h
+++ b/Kerberos/src/Platform/Vulkan/VulkanFramebuffer.h
@@ -27,8 +27,8 @@ namespace Kerberos
 	private:
 		void ReleaseResources();
 
-		void CreateImage(uint32_t width, uint32_t height, VkFormat format, VkImageTiling tiling, VkImageUsageFlags usage, VkMemoryPropertyFlags properties, VkImage& image, VkDeviceMemory& memory) const;
-		void CreateImageView(VkImage image, VkFormat format, VkImageAspectFlags flags, VkImageView& imageView) const;
+		static void CreateImage(uint32_t width, uint32_t height, VkFormat format, VkImageTiling tiling, VkImageUsageFlags usage, VkMemoryPropertyFlags properties, VkImage& image, VkDeviceMemory& memory);
+		static void CreateImageView(VkImage image, VkFormat format, VkImageAspectFlags flags, VkImageView& imageView);
 
 	private:
 		FramebufferSpecification m_Specification;

--- a/Kerberos/src/Platform/Vulkan/VulkanHelpers.h
+++ b/Kerberos/src/Platform/Vulkan/VulkanHelpers.h
@@ -31,7 +31,7 @@ namespace Kerberos
                 }
             }
             KBR_CORE_ASSERT(false, "Failed to find suitable memory type!");
-            return 0;
+            return 0xFFFFFFFF;
 		}
 
         static VkResult CreateDebugUtilsMessengerEXT(const VkInstance instance, const VkDebugUtilsMessengerCreateInfoEXT* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkDebugUtilsMessengerEXT* pDebugMessenger)

--- a/Kerberos/src/Platform/Vulkan/VulkanHelpers.h
+++ b/Kerberos/src/Platform/Vulkan/VulkanHelpers.h
@@ -19,6 +19,21 @@ namespace Kerberos
 	class VulkanHelpers
 	{
 	public:
+        static uint32_t FindMemoryType(const VkPhysicalDevice physicalDevice, const uint32_t typeFilter, const VkMemoryPropertyFlags properties)
+        {
+            VkPhysicalDeviceMemoryProperties memProperties;
+            vkGetPhysicalDeviceMemoryProperties(physicalDevice, &memProperties);
+            for (uint32_t i = 0; i < memProperties.memoryTypeCount; i++)
+            {
+                if ((typeFilter & (1 << i)) && (memProperties.memoryTypes[i].propertyFlags & properties) == properties)
+                {
+                    return i;
+                }
+            }
+            KBR_CORE_ASSERT(false, "Failed to find suitable memory type!");
+            return 0;
+		}
+
         static VkResult CreateDebugUtilsMessengerEXT(const VkInstance instance, const VkDebugUtilsMessengerCreateInfoEXT* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkDebugUtilsMessengerEXT* pDebugMessenger)
         {
             const auto func = reinterpret_cast<PFN_vkCreateDebugUtilsMessengerEXT>(vkGetInstanceProcAddr(instance, "vkCreateDebugUtilsMessengerEXT"));

--- a/Kerberos/src/Platform/Vulkan/VulkanTexture.cpp
+++ b/Kerberos/src/Platform/Vulkan/VulkanTexture.cpp
@@ -8,6 +8,73 @@
 
 namespace Kerberos
 {
+    namespace Utils
+    {
+		/// This is really not optimised and should be replaced with a better solution.
+        void TransitionImageLayout(const VkCommandBuffer commandBuffer, const VkImage image, VkFormat format, const VkImageLayout oldLayout, const VkImageLayout newLayout)
+        {
+            VkImageMemoryBarrier barrier{};
+            barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+            barrier.oldLayout = oldLayout;
+            barrier.newLayout = newLayout;
+            barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+            barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+            barrier.image = image;
+            barrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+            barrier.subresourceRange.baseMipLevel = 0;
+            barrier.subresourceRange.levelCount = 1;
+            barrier.subresourceRange.baseArrayLayer = 0;
+            barrier.subresourceRange.layerCount = 1;
+
+            VkPipelineStageFlags sourceStage;
+            VkPipelineStageFlags destinationStage;
+
+            if (oldLayout == VK_IMAGE_LAYOUT_UNDEFINED && newLayout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL)
+            {
+                barrier.srcAccessMask = 0;
+                barrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+                sourceStage = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
+                destinationStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
+            }
+            else if (oldLayout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL && newLayout == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL)
+            {
+                barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+                barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+                sourceStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
+                destinationStage = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+            }
+            else if (oldLayout == VK_IMAGE_LAYOUT_UNDEFINED && newLayout == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL)
+            {
+                // For creating an empty texture and directly making it shader readable
+                barrier.srcAccessMask = 0;
+                barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT; // Or 0 if no read access needed immediately after transition
+                sourceStage = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
+                destinationStage = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT; // Or PIPELINE_STAGE_ALL_COMMANDS_BIT if unsure
+            }
+            else if (oldLayout == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL && newLayout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL)
+            {
+                barrier.srcAccessMask = VK_ACCESS_SHADER_READ_BIT;
+                barrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+                sourceStage = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+                destinationStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
+            }
+            else
+            {
+                KBR_CORE_ERROR("Unsupported layout transition!");
+                return;
+            }
+
+            vkCmdPipelineBarrier(
+                commandBuffer,
+                sourceStage, destinationStage,
+                0,
+                0, nullptr,
+                0, nullptr,
+                1, &barrier
+            );
+        }
+    }
+
 	VulkanTexture2D::VulkanTexture2D(const std::string& path)
 		: m_Path(path)
 	{
@@ -195,7 +262,6 @@ namespace Kerberos
 
         stbi_image_free(imageData);
 
-		VkCommandPool commandPool = context.GetCommandPool();
 		VkCommandBuffer commandBuffer = context.GetCommandBuffer();
 
         /// Copy to Image
@@ -244,9 +310,170 @@ namespace Kerberos
         m_RendererID = reinterpret_cast<ImTextureID>(m_DescriptorSet);
 	}
 
-	VulkanTexture2D::VulkanTexture2D(uint32_t width, uint32_t height)
+	VulkanTexture2D::VulkanTexture2D(const uint32_t width, const uint32_t height)
+		: m_Width(width), m_Height(height)
 	{
-		
+        KBR_PROFILE_FUNCTION();
+
+        KBR_ASSERT(width > 0 && height > 0, "Texture dimensions must be greater than 0");
+
+        uint32_t imageSize = m_Width * m_Height * 4; // 4 bytes per pixel (RGBA)
+
+        const VulkanContext& context = VulkanContext::Get();
+        const VkDevice device = context.GetDevice();
+        const VkPhysicalDevice physicalDevice = context.GetPhysicalDevice();
+        VkResult err;
+
+        /// Create the image
+        {
+            VkImageCreateInfo imageInfo{};
+            imageInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+            imageInfo.imageType = VK_IMAGE_TYPE_2D;
+            imageInfo.format = VK_FORMAT_R8G8B8A8_UNORM;
+            imageInfo.extent.width = m_Width;
+            imageInfo.extent.height = m_Height;
+            imageInfo.extent.depth = 1;
+            imageInfo.mipLevels = 1;
+            imageInfo.arrayLayers = 1;
+            imageInfo.samples = VK_SAMPLE_COUNT_1_BIT;
+            imageInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
+            // Need TRANSFER_DST_BIT for SetData, SAMPLED_BIT for sampling
+            imageInfo.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+            imageInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+            imageInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED; // Will transition it
+
+            err = vkCreateImage(device, &imageInfo, nullptr, &m_Image);
+            if (err != VK_SUCCESS)
+            {
+                KBR_ERROR("Failed to create Vulkan image (empty): {}", VulkanHelpers::VkResultToString(err));
+                return;
+            }
+
+            VkMemoryRequirements req;
+            vkGetImageMemoryRequirements(device, m_Image, &req);
+            VkMemoryAllocateInfo allocInfo{};
+            allocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+            allocInfo.allocationSize = req.size;
+            allocInfo.memoryTypeIndex = VulkanHelpers::FindMemoryType(physicalDevice, req.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+
+            err = vkAllocateMemory(device, &allocInfo, nullptr, &m_ImageMemory);
+            if (err != VK_SUCCESS)
+            {
+                KBR_ERROR("Failed to allocate Vulkan image memory (empty): {}", VulkanHelpers::VkResultToString(err));
+                vkDestroyImage(device, m_Image, nullptr);
+                return;
+            }
+            err = vkBindImageMemory(device, m_Image, m_ImageMemory, 0);
+            if (err != VK_SUCCESS)
+            {
+                KBR_ERROR("Failed to bind Vulkan image memory (empty): {}", VulkanHelpers::VkResultToString(err));
+                vkFreeMemory(device, m_ImageMemory, nullptr);
+                vkDestroyImage(device, m_Image, nullptr);
+                return;
+            }
+        }
+
+        /// Create the Image View
+        {
+            VkImageViewCreateInfo imageViewInfo{};
+            imageViewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+            imageViewInfo.image = m_Image;
+            imageViewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
+            imageViewInfo.format = VK_FORMAT_R8G8B8A8_UNORM;
+            imageViewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+            imageViewInfo.subresourceRange.levelCount = 1;
+            imageViewInfo.subresourceRange.layerCount = 1;
+            err = vkCreateImageView(device, &imageViewInfo, nullptr, &m_ImageView);
+            if (err != VK_SUCCESS)
+            {
+                KBR_ERROR("Failed to create Vulkan image view (empty): {}", VulkanHelpers::VkResultToString(err));
+                vkFreeMemory(device, m_ImageMemory, nullptr);
+                vkDestroyImage(device, m_Image, nullptr);
+                return;
+            }
+        }
+
+        /// Create Sampler
+        {
+            VkSamplerCreateInfo samplerInfo{};
+            samplerInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+            samplerInfo.magFilter = VK_FILTER_LINEAR;
+            samplerInfo.minFilter = VK_FILTER_LINEAR;
+            samplerInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
+            samplerInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+            samplerInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+            samplerInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+            samplerInfo.minLod = 0.0f;
+            samplerInfo.maxLod = 1.0f; // Or VK_LOD_CLAMP_NONE if mipLevels > 1
+            samplerInfo.maxAnisotropy = 1.0f;
+            err = vkCreateSampler(device, &samplerInfo, nullptr, &m_Sampler);
+            if (err != VK_SUCCESS)
+            {
+                KBR_ERROR("Failed to create Vulkan sampler (empty): {}", VulkanHelpers::VkResultToString(err));
+                vkDestroyImageView(device, m_ImageView, nullptr);
+                vkFreeMemory(device, m_ImageMemory, nullptr);
+                vkDestroyImage(device, m_Image, nullptr);
+                return;
+            }
+        }
+
+        /// Create Upload Buffer (will be used by SetData)
+        {
+            VkBufferCreateInfo bufferInfo{};
+            bufferInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+            bufferInfo.size = imageSize; // Size for the pixel data
+            bufferInfo.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+            bufferInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+            err = vkCreateBuffer(device, &bufferInfo, nullptr, &m_UploadBuffer);
+            if (err != VK_SUCCESS)
+            {
+                KBR_ERROR("Failed to create Vulkan upload buffer (empty tex): {}", VulkanHelpers::VkResultToString(err));
+                // Clean up previously allocated resources
+                vkDestroySampler(device, m_Sampler, nullptr);
+                vkDestroyImageView(device, m_ImageView, nullptr);
+                vkFreeMemory(device, m_ImageMemory, nullptr);
+                vkDestroyImage(device, m_Image, nullptr);
+                return;
+            }
+
+            VkMemoryRequirements req;
+            vkGetBufferMemoryRequirements(device, m_UploadBuffer, &req);
+            VkMemoryAllocateInfo allocInfo{};
+            allocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+            allocInfo.allocationSize = req.size;
+            // HOST_COHERENT makes flushes automatic on unmap, or vkFlushMappedMemoryRanges can be manual
+            allocInfo.memoryTypeIndex = VulkanHelpers::FindMemoryType(physicalDevice, req.memoryTypeBits, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+            err = vkAllocateMemory(device, &allocInfo, nullptr, &m_UploadBufferMemory);
+            if (err != VK_SUCCESS)
+            {
+                KBR_ERROR("Failed to allocate Vulkan upload buffer memory (empty tex): {}", VulkanHelpers::VkResultToString(err));
+                vkDestroyBuffer(device, m_UploadBuffer, nullptr);
+                vkDestroySampler(device, m_Sampler, nullptr);
+                vkDestroyImageView(device, m_ImageView, nullptr);
+                vkFreeMemory(device, m_ImageMemory, nullptr);
+                vkDestroyImage(device, m_Image, nullptr);
+                return;
+            }
+            err = vkBindBufferMemory(device, m_UploadBuffer, m_UploadBufferMemory, 0);
+            if (err != VK_SUCCESS)
+            {
+                KBR_ERROR("Failed to bind Vulkan upload buffer memory (empty tex): {}", VulkanHelpers::VkResultToString(err));
+                vkFreeMemory(device, m_UploadBufferMemory, nullptr);
+                vkDestroyBuffer(device, m_UploadBuffer, nullptr);
+                vkDestroySampler(device, m_Sampler, nullptr);
+                vkDestroyImageView(device, m_ImageView, nullptr);
+                vkFreeMemory(device, m_ImageMemory, nullptr);
+                vkDestroyImage(device, m_Image, nullptr);
+                return;
+            }
+        }
+
+        VkCommandBuffer commandBuffer = context.GetCommandBuffer();
+        Utils::TransitionImageLayout(commandBuffer, m_Image, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+        context.SubmitCommandBuffer(commandBuffer);
+
+        m_DescriptorSet = ImGui_ImplVulkan_AddTexture(m_Sampler, m_ImageView, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+        m_RendererID = reinterpret_cast<ImTextureID>(m_DescriptorSet);
 	}
 
 	VulkanTexture2D::~VulkanTexture2D()
@@ -256,12 +483,68 @@ namespace Kerberos
 
 	void VulkanTexture2D::Bind(uint32_t slot) const
 	{
-		
+        // vkCmdBindDescriptorSets()
 	}
 
 	void VulkanTexture2D::SetData(void* data, uint32_t size)
 	{
-		
+        KBR_PROFILE_FUNCTION();
+
+        KBR_CORE_ASSERT(data, "Data cannot be null when uploading to texture");
+
+        uint32_t expectedSize = m_Width * m_Height * 4; // Assuming RGBA8
+        KBR_ASSERT(size == expectedSize, "Data size mismatch! Expected {} bytes, got {} bytes.", expectedSize, size);
+        if (size != expectedSize || !data)
+        {
+            KBR_ERROR("Invalid data or size for SetData. Expected size: {}, actual size: {}", expectedSize, size);
+            return;
+        }
+
+        const VulkanContext& context = VulkanContext::Get();
+
+        /// Copy data to upload buffer
+        {
+	        const VkDevice device = context.GetDevice();
+	        void* map = nullptr;
+            VkResult err = vkMapMemory(device, m_UploadBufferMemory, 0, size, 0, &map);
+            if (err != VK_SUCCESS)
+            {
+                KBR_ERROR("Failed to map Vulkan upload buffer memory for SetData: {}", VulkanHelpers::VkResultToString(err));
+                return;
+            }
+            memcpy(map, data, size);
+            // If memory is not HOST_COHERENT, flush is needed:
+            // VkMappedMemoryRange range{};
+            // range.sType = VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE;
+            // range.memory = m_UploadBufferMemory;
+            // range.offset = 0;
+            // range.size = size;
+            // vkFlushMappedMemoryRanges(device, 1, &range);
+            vkUnmapMemory(device, m_UploadBufferMemory);
+        }
+
+        const VkCommandBuffer commandBuffer = context.GetCommandBuffer();
+
+        /// Transition image from SHADER_READ_ONLY (current) to TRANSFER_DST
+        Utils::TransitionImageLayout(commandBuffer, m_Image, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+
+        /// Copy buffer to image
+        VkBufferImageCopy region{};
+        region.bufferOffset = 0;
+        region.bufferRowLength = 0;
+        region.bufferImageHeight = 0;
+        region.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+        region.imageSubresource.mipLevel = 0;
+        region.imageSubresource.baseArrayLayer = 0;
+        region.imageSubresource.layerCount = 1;
+        region.imageOffset = { .x = 0, .y = 0, .z = 0 };
+        region.imageExtent = { .width = m_Width, .height = m_Height, .depth = 1 };
+        vkCmdCopyBufferToImage(commandBuffer, m_UploadBuffer, m_Image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
+
+        /// Transition image from TRANSFER_DST to SHADER_READ_ONLY for sampling
+        Utils::TransitionImageLayout(commandBuffer, m_Image, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+
+        context.SubmitCommandBuffer(commandBuffer);
 	}
 
 	void VulkanTexture2D::CleanupResources() const 
@@ -269,14 +552,14 @@ namespace Kerberos
 		KBR_PROFILE_FUNCTION();
 
 		const VulkanContext& context = VulkanContext::Get();
-		const VkDevice gDevice = context.GetDevice();
+		const VkDevice device = context.GetDevice();
 
-        vkFreeMemory(gDevice, m_UploadBufferMemory, nullptr);
-        vkDestroyBuffer(gDevice, m_UploadBuffer, nullptr);
-        vkDestroySampler(gDevice, m_Sampler, nullptr);
-        vkDestroyImageView(gDevice, m_ImageView, nullptr);
-        vkDestroyImage(gDevice, m_Image, nullptr);
-        vkFreeMemory(gDevice, m_ImageMemory, nullptr);
+        vkFreeMemory(device, m_UploadBufferMemory, nullptr);
+        vkDestroyBuffer(device, m_UploadBuffer, nullptr);
+        vkDestroySampler(device, m_Sampler, nullptr);
+        vkDestroyImageView(device, m_ImageView, nullptr);
+        vkDestroyImage(device, m_Image, nullptr);
+        vkFreeMemory(device, m_ImageMemory, nullptr);
         ImGui_ImplVulkan_RemoveTexture(m_DescriptorSet);
 	}
 }

--- a/Kerberos/src/Platform/Vulkan/VulkanTexture.cpp
+++ b/Kerberos/src/Platform/Vulkan/VulkanTexture.cpp
@@ -1,11 +1,224 @@
 #include "kbrpch.h"
 #include "VulkanTexture.h"
 
+#include <stb_image.h>
+#include <backends/imgui_impl_vulkan.h>
+
+#include "VulkanContext.h"
+
 namespace Kerberos
 {
 	VulkanTexture2D::VulkanTexture2D(const std::string& path)
+		: m_Path(path)
 	{
-		
+		KBR_PROFILE_FUNCTION();
+
+		int width, height, channels;
+
+		//stbi_set_flip_vertically_on_load(true);
+
+		stbi_uc* imageData = nullptr;
+		{
+			KBR_PROFILE_SCOPE("stbi_load - VulkanTexture2D::VulkanTexture2D(const std::string& path)");
+			/// Set the desired number of channels to 4 (RGBA) for Vulkan compatibility
+			imageData = stbi_load(path.c_str(), &width, &height, &channels, 4);
+		}
+
+		KBR_ASSERT(imageData, "Failed to load image!");
+
+		m_Width = static_cast<unsigned int>(width);
+		m_Height = static_cast<unsigned int>(height);
+
+		uint32_t imageSize = m_Width * m_Height * 4;
+
+		const VulkanContext& context = VulkanContext::Get();
+		const VkDevice device = context.GetDevice();
+		const VkPhysicalDevice physicalDevice = context.GetPhysicalDevice();
+
+        VkResult err;
+
+        /// Create the image.
+        {
+            VkImageCreateInfo imageInfo = {};
+            imageInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+            imageInfo.imageType = VK_IMAGE_TYPE_2D;
+            imageInfo.format = VK_FORMAT_R8G8B8A8_UNORM;
+            imageInfo.extent.width = m_Width;
+            imageInfo.extent.height = m_Height;
+            imageInfo.extent.depth = 1;
+            imageInfo.mipLevels = 1;
+            imageInfo.arrayLayers = 1;
+            imageInfo.samples = VK_SAMPLE_COUNT_1_BIT;
+            imageInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
+            imageInfo.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+            imageInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+            imageInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+            err = vkCreateImage(device, &imageInfo, nullptr, &m_Image);
+
+            VkMemoryRequirements req;
+            vkGetImageMemoryRequirements(device, m_Image, &req);
+            VkMemoryAllocateInfo allocInfo = {};
+
+            allocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+            allocInfo.allocationSize = req.size;
+            allocInfo.memoryTypeIndex = VulkanHelpers::FindMemoryType(physicalDevice, req.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+
+            err = vkAllocateMemory(device, &allocInfo, nullptr, &m_ImageMemory);
+
+            err = vkBindImageMemory(device, m_Image, m_ImageMemory, 0);
+        }
+
+        /// Create the Image View
+        {
+            VkImageViewCreateInfo imageViewInfo = {};
+            imageViewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+            imageViewInfo.image = m_Image;
+            imageViewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
+            imageViewInfo.format = VK_FORMAT_R8G8B8A8_UNORM;
+            imageViewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+            imageViewInfo.subresourceRange.levelCount = 1;
+            imageViewInfo.subresourceRange.layerCount = 1;
+
+            err = vkCreateImageView(device, &imageViewInfo, nullptr, &m_ImageView);
+        }
+
+        /// Create Sampler
+        {
+            VkSamplerCreateInfo samplerInfo{};
+            samplerInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+            samplerInfo.magFilter = VK_FILTER_LINEAR;
+            samplerInfo.minFilter = VK_FILTER_LINEAR;
+            samplerInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
+            samplerInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_REPEAT; // outside image bounds just use border color
+            samplerInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+            samplerInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+            samplerInfo.minLod = -1000;
+            samplerInfo.maxLod = 1000;
+            samplerInfo.maxAnisotropy = 1.0f;
+
+            err = vkCreateSampler(device, &samplerInfo, nullptr, &m_Sampler);
+        }
+
+        /// Create Descriptor Set using ImGUI's implementation
+        m_DescriptorSet = ImGui_ImplVulkan_AddTexture(m_Sampler, m_ImageView, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+
+        /// Create Upload Buffer
+        {
+            VkBufferCreateInfo bufferInfo = {};
+            bufferInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+            bufferInfo.size = imageSize;
+            bufferInfo.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+            bufferInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+            err = vkCreateBuffer(device, &bufferInfo, nullptr, &m_UploadBuffer);
+
+            VkMemoryRequirements req;
+            vkGetBufferMemoryRequirements(device, m_UploadBuffer, &req);
+
+            VkMemoryAllocateInfo allocInfo = {};
+            allocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+            allocInfo.allocationSize = req.size;
+            allocInfo.memoryTypeIndex = VulkanHelpers::FindMemoryType(physicalDevice, req.memoryTypeBits, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
+
+            err = vkAllocateMemory(device, &allocInfo, nullptr, &m_UploadBufferMemory);
+
+            err = vkBindBufferMemory(device, m_UploadBuffer, m_UploadBufferMemory, 0);
+        }
+
+        /// Upload to Buffer:
+        {
+            void* map = nullptr;
+
+            err = vkMapMemory(device, m_UploadBufferMemory, 0, imageSize, 0, &map);
+
+            memcpy(map, imageData, imageSize);
+
+            VkMappedMemoryRange range[1] = {};
+            range[0].sType = VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE;
+            range[0].memory = m_UploadBufferMemory;
+            range[0].size = imageSize;
+
+            err = vkFlushMappedMemoryRanges(device, 1, range);
+
+            vkUnmapMemory(device, m_UploadBufferMemory);
+        }
+
+        stbi_image_free(imageData);
+
+		VkCommandPool commandPool = context.GetCommandPool();
+		VkCommandBuffer commandBuffer = context.GetCommandBuffer();
+        /*{
+            VkCommandBufferAllocateInfo allocInfo{};
+            allocInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+            allocInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+            allocInfo.commandPool = commandPool;
+            allocInfo.commandBufferCount = 1;
+
+            err = vkAllocateCommandBuffers(device, &allocInfo, &commandBuffer);
+
+            VkCommandBufferBeginInfo beginInfo = {};
+            beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+            beginInfo.flags |= VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+
+            err = vkBeginCommandBuffer(commandBuffer, &beginInfo);
+        }*/
+
+        /// Copy to Image
+        {
+            VkImageMemoryBarrier copyBarrier[1] = {};
+            copyBarrier[0].sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+            copyBarrier[0].dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+            copyBarrier[0].oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+            copyBarrier[0].newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+            copyBarrier[0].srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+            copyBarrier[0].dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+            copyBarrier[0].image = m_Image;
+            copyBarrier[0].subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+            copyBarrier[0].subresourceRange.levelCount = 1;
+            copyBarrier[0].subresourceRange.layerCount = 1;
+
+            vkCmdPipelineBarrier(commandBuffer, VK_PIPELINE_STAGE_HOST_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, 1, copyBarrier);
+
+            VkBufferImageCopy region = {};
+            region.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+            region.imageSubresource.layerCount = 1;
+            region.imageExtent.width = m_Width;
+            region.imageExtent.height = m_Height;
+            region.imageExtent.depth = 1;
+            vkCmdCopyBufferToImage(commandBuffer, m_UploadBuffer, m_Image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
+
+            VkImageMemoryBarrier useBarrier[1] = {};
+            useBarrier[0].sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+            useBarrier[0].srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+            useBarrier[0].dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+            useBarrier[0].oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+            useBarrier[0].newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+            useBarrier[0].srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+            useBarrier[0].dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+            useBarrier[0].image = m_Image;
+            useBarrier[0].subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+            useBarrier[0].subresourceRange.levelCount = 1;
+            useBarrier[0].subresourceRange.layerCount = 1;
+
+            vkCmdPipelineBarrier(commandBuffer, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0, 0, nullptr, 0, nullptr, 1, useBarrier);
+        }
+
+        /// End command buffer
+		context.SubmitCommandBuffer(commandBuffer);
+        /*{
+            VkSubmitInfo endInfo = {};
+            endInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+            endInfo.commandBufferCount = 1;
+            endInfo.pCommandBuffers = &commandBuffer;
+
+            err = vkEndCommandBuffer(commandBuffer);
+
+            err = vkQueueSubmit(g_Queue, 1, &endInfo, VK_NULL_HANDLE);
+
+            err = vkDeviceWaitIdle(device);
+        }*/
+
+        m_RendererID = reinterpret_cast<ImTextureID>(m_DescriptorSet);
 	}
 
 	VulkanTexture2D::VulkanTexture2D(uint32_t width, uint32_t height)
@@ -15,7 +228,7 @@ namespace Kerberos
 
 	VulkanTexture2D::~VulkanTexture2D()
 	{
-		
+		CleanupResources();
 	}
 
 	void VulkanTexture2D::Bind(uint32_t slot) const
@@ -26,5 +239,21 @@ namespace Kerberos
 	void VulkanTexture2D::SetData(void* data, uint32_t size)
 	{
 		
+	}
+
+	void VulkanTexture2D::CleanupResources() const 
+    {
+		KBR_PROFILE_FUNCTION();
+
+		const VulkanContext& context = VulkanContext::Get();
+		const VkDevice gDevice = context.GetDevice();
+
+        vkFreeMemory(gDevice, m_UploadBufferMemory, nullptr);
+        vkDestroyBuffer(gDevice, m_UploadBuffer, nullptr);
+        vkDestroySampler(gDevice, m_Sampler, nullptr);
+        vkDestroyImageView(gDevice, m_ImageView, nullptr);
+        vkDestroyImage(gDevice, m_Image, nullptr);
+        vkFreeMemory(gDevice, m_ImageMemory, nullptr);
+        ImGui_ImplVulkan_RemoveTexture(m_DescriptorSet);
 	}
 }

--- a/Kerberos/src/Platform/Vulkan/VulkanTexture.cpp
+++ b/Kerberos/src/Platform/Vulkan/VulkanTexture.cpp
@@ -262,7 +262,7 @@ namespace Kerberos
 
         stbi_image_free(imageData);
 
-		VkCommandBuffer commandBuffer = context.GetCommandBuffer();
+		VkCommandBuffer commandBuffer = context.GetOneTimeCommandBuffer();
 
         /// Copy to Image
         {
@@ -306,8 +306,6 @@ namespace Kerberos
 
         /// End command buffer
 		context.SubmitCommandBuffer(commandBuffer);
-
-        m_RendererID = reinterpret_cast<ImTextureID>(m_DescriptorSet);
 	}
 
 	VulkanTexture2D::VulkanTexture2D(const uint32_t width, const uint32_t height)
@@ -468,12 +466,11 @@ namespace Kerberos
             }
         }
 
-        VkCommandBuffer commandBuffer = context.GetCommandBuffer();
+        VkCommandBuffer commandBuffer = context.GetOneTimeCommandBuffer();
         Utils::TransitionImageLayout(commandBuffer, m_Image, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
         context.SubmitCommandBuffer(commandBuffer);
 
         m_DescriptorSet = ImGui_ImplVulkan_AddTexture(m_Sampler, m_ImageView, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
-        m_RendererID = reinterpret_cast<ImTextureID>(m_DescriptorSet);
 	}
 
 	VulkanTexture2D::~VulkanTexture2D()
@@ -481,9 +478,14 @@ namespace Kerberos
 		CleanupResources();
 	}
 
+	uint64_t VulkanTexture2D::GetRendererID() const 
+    {
+        return reinterpret_cast<ImTextureID>(m_DescriptorSet);
+    }
+
 	void VulkanTexture2D::Bind(uint32_t slot) const
 	{
-        // vkCmdBindDescriptorSets()
+        //vkCmdBindDescriptorSets()
 	}
 
 	void VulkanTexture2D::SetData(void* data, uint32_t size)
@@ -523,7 +525,7 @@ namespace Kerberos
             vkUnmapMemory(device, m_UploadBufferMemory);
         }
 
-        const VkCommandBuffer commandBuffer = context.GetCommandBuffer();
+        const VkCommandBuffer commandBuffer = context.GetOneTimeCommandBuffer();
 
         /// Transition image from SHADER_READ_ONLY (current) to TRANSFER_DST
         Utils::TransitionImageLayout(commandBuffer, m_Image, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);

--- a/Kerberos/src/Platform/Vulkan/VulkanTexture.h
+++ b/Kerberos/src/Platform/Vulkan/VulkanTexture.h
@@ -8,8 +8,6 @@ namespace Kerberos
 {
 	class VulkanTexture2D final : public Texture2D
 	{
-		using RendererID = uint64_t;
-
 	public:
 		explicit VulkanTexture2D(const std::string& path);
 		explicit VulkanTexture2D(uint32_t width, uint32_t height);
@@ -18,7 +16,7 @@ namespace Kerberos
 		uint32_t GetWidth() const override { return m_Width; }
 		uint32_t GetHeight() const override { return m_Height; }
 
-		RendererID GetRendererID() const override { return m_RendererID; }
+		uint64_t GetRendererID() const override;
 
 		void Bind(uint32_t slot = 0) const override;
 
@@ -26,14 +24,14 @@ namespace Kerberos
 
 		bool operator==(const Texture& other) const override
 		{
-			return m_RendererID == dynamic_cast<const VulkanTexture2D&>(other).m_RendererID;
+			/// TODO: Test if this works
+			return m_DescriptorSet == dynamic_cast<const VulkanTexture2D&>(other).m_DescriptorSet;
 		}
 
 	private:
 		void CleanupResources() const;
 
 	private:
-		RendererID m_RendererID = 0;
 		uint32_t m_Width = 0;
 		uint32_t m_Height = 0;
 		std::string m_Path;

--- a/Kerberos/src/Platform/Vulkan/VulkanTexture.h
+++ b/Kerberos/src/Platform/Vulkan/VulkanTexture.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <vulkan/vulkan_core.h>
+
 #include "Kerberos/Renderer/Texture.h"
 
 namespace Kerberos
@@ -28,9 +30,21 @@ namespace Kerberos
 		}
 
 	private:
+		void CleanupResources() const;
+
+	private:
 		RendererID m_RendererID = 0;
 		uint32_t m_Width = 0;
 		uint32_t m_Height = 0;
+		std::string m_Path;
+
+		VkImage         m_Image;
+		VkImageView     m_ImageView;
+		VkDeviceMemory  m_ImageMemory;
+		VkSampler       m_Sampler;
+		VkBuffer        m_UploadBuffer;
+		VkDeviceMemory  m_UploadBufferMemory;
+		VkDescriptorSet m_DescriptorSet;
 	};
 }
 

--- a/KerberosEditor/imgui.ini
+++ b/KerberosEditor/imgui.ini
@@ -33,7 +33,7 @@ Collapsed=0
 DockId=0x00000006,0
 
 [Docking][Data]
-DockSpace       ID=0xC0DFADC4 Window=0xD0388BC8 Pos=201,254 Size=1280,696 Split=X Selected=0x4746B4B8
+DockSpace       ID=0xC0DFADC4 Window=0xD0388BC8 Pos=545,233 Size=1280,696 Split=X Selected=0x4746B4B8
   DockNode      ID=0x00000003 Parent=0xC0DFADC4 SizeRef=906,701 Split=X
     DockNode    ID=0x00000001 Parent=0x00000003 SizeRef=391,701 Split=Y Selected=0xBABDAE5E
       DockNode  ID=0x00000005 Parent=0x00000001 SizeRef=178,237 CentralNode=1 Selected=0xBABDAE5E

--- a/KerberosEditor/imgui.ini
+++ b/KerberosEditor/imgui.ini
@@ -1,6 +1,6 @@
 [Window][DockSpace Demo]
 Pos=0,0
-Size=1920,991
+Size=1280,720
 Collapsed=0
 
 [Window][Debug##Default]
@@ -9,35 +9,35 @@ Size=400,400
 Collapsed=0
 
 [Window][Settings]
-Pos=1548,24
-Size=372,967
+Pos=908,24
+Size=372,696
 Collapsed=0
 DockId=0x00000004,0
 
 [Window][Viewport]
-Pos=350,24
-Size=1196,967
+Pos=393,24
+Size=513,696
 Collapsed=0
 DockId=0x00000002,0
 
 [Window][Hierarchy]
 Pos=0,24
-Size=348,503
+Size=391,232
 Collapsed=0
 DockId=0x00000005,0
 
 [Window][Properties]
-Pos=0,529
-Size=348,462
+Pos=0,258
+Size=391,462
 Collapsed=0
 DockId=0x00000006,0
 
 [Docking][Data]
-DockSpace       ID=0xC0DFADC4 Window=0xD0388BC8 Pos=0,53 Size=1920,967 Split=X Selected=0x4746B4B8
+DockSpace       ID=0xC0DFADC4 Window=0xD0388BC8 Pos=201,254 Size=1280,696 Split=X Selected=0x4746B4B8
   DockNode      ID=0x00000003 Parent=0xC0DFADC4 SizeRef=906,701 Split=X
-    DockNode    ID=0x00000001 Parent=0x00000003 SizeRef=348,701 Split=Y Selected=0xBABDAE5E
+    DockNode    ID=0x00000001 Parent=0x00000003 SizeRef=391,701 Split=Y Selected=0xBABDAE5E
       DockNode  ID=0x00000005 Parent=0x00000001 SizeRef=178,237 CentralNode=1 Selected=0xBABDAE5E
       DockNode  ID=0x00000006 Parent=0x00000001 SizeRef=178,462 Selected=0x8C72BEA8
-    DockNode    ID=0x00000002 Parent=0x00000003 SizeRef=1196,701 Selected=0xC450F867
+    DockNode    ID=0x00000002 Parent=0x00000003 SizeRef=513,701 Selected=0xC450F867
   DockNode      ID=0x00000004 Parent=0xC0DFADC4 SizeRef=372,701 Selected=0x4746B4B8
 

--- a/KerberosEditor/imgui.ini
+++ b/KerberosEditor/imgui.ini
@@ -1,6 +1,6 @@
 [Window][DockSpace Demo]
 Pos=0,0
-Size=1280,720
+Size=1920,991
 Collapsed=0
 
 [Window][Debug##Default]
@@ -9,35 +9,35 @@ Size=400,400
 Collapsed=0
 
 [Window][Settings]
-Pos=908,24
-Size=372,696
+Pos=1548,24
+Size=372,967
 Collapsed=0
 DockId=0x00000004,0
 
 [Window][Viewport]
-Pos=246,24
-Size=660,696
+Pos=350,24
+Size=1196,967
 Collapsed=0
 DockId=0x00000002,0
 
 [Window][Hierarchy]
 Pos=0,24
-Size=244,232
+Size=348,503
 Collapsed=0
 DockId=0x00000005,0
 
 [Window][Properties]
-Pos=0,258
-Size=244,462
+Pos=0,529
+Size=348,462
 Collapsed=0
 DockId=0x00000006,0
 
 [Docking][Data]
-DockSpace       ID=0xC0DFADC4 Window=0xD0388BC8 Pos=41,94 Size=1280,696 Split=X Selected=0x4746B4B8
+DockSpace       ID=0xC0DFADC4 Window=0xD0388BC8 Pos=0,53 Size=1920,967 Split=X Selected=0x4746B4B8
   DockNode      ID=0x00000003 Parent=0xC0DFADC4 SizeRef=906,701 Split=X
-    DockNode    ID=0x00000001 Parent=0x00000003 SizeRef=376,701 Split=Y Selected=0xBABDAE5E
+    DockNode    ID=0x00000001 Parent=0x00000003 SizeRef=348,701 Split=Y Selected=0xBABDAE5E
       DockNode  ID=0x00000005 Parent=0x00000001 SizeRef=178,237 CentralNode=1 Selected=0xBABDAE5E
       DockNode  ID=0x00000006 Parent=0x00000001 SizeRef=178,462 Selected=0x8C72BEA8
-    DockNode    ID=0x00000002 Parent=0x00000003 SizeRef=660,701 Selected=0xC450F867
+    DockNode    ID=0x00000002 Parent=0x00000003 SizeRef=1196,701 Selected=0xC450F867
   DockNode      ID=0x00000004 Parent=0xC0DFADC4 SizeRef=372,701 Selected=0x4746B4B8
 


### PR DESCRIPTION
Implemented a somewhat working `VulkanFramebuffer` class, which begins the renderpass on `Bind()`, and ends it on `Unbind()`.
However there are a lot of things to do, since the `VulkanContext` doesn't have a render loop, it does everything in `SwapBuffers()`, thus making it impossible for the render commands issued inside any of the Layers to succeed.

The implemented `VulkanTexture` seems alright, however the descriptor sets are created via `ImGui_ImplVulkan_AddTexture()`, which uses the `DescriptorPool` supplied to it when setting up ImGui, but uses the `DescriptorSetLayout` which ImGui uses for their textures.
This could be why when trying to render textures the validation layer tells us that we're trying to bind an invalid `VkDescriptorSet`.

I added a new `As<T>()` method on renderer resources, which can be used to cast the generic class into a graphics api specific class.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added utility methods for Vulkan command buffer management, including allocation and submission of one-time command buffers.
  - Implemented full Vulkan resource management for framebuffers and textures, including creation, binding, resizing, and cleanup.
  - Introduced type-casting utility methods across various rendering classes for flexible object handling.

- **Improvements**
  - Enhanced Vulkan buffer and framebuffer handling for more robust and accurate state management.
  - Improved integration with ImGui for Vulkan textures and framebuffers.

- **Style**
  - Updated editor window layout and docking configuration for a more organized user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->